### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a script tag to your page pointed at the livereload server
 ## Options
 
 - `port` - (Default: 35729) The desired port for the livereload server
-- `appendScript` - (Default: false) Append livereload `<script>`
+- `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.
 
 ## Why?


### PR DESCRIPTION
Fixed typo. In source https://github.com/statianzo/webpack-livereload-plugin/blob/master/index.js#L71 options item called `appendScriptTag`