### PR TITLE
Fix document undefined error when using ExtractTextPlugin, tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a script tag to your page pointed at the livereload server
 ## Options
 
 - `port` - (Default: 35729) The desired port for the livereload server
-- `appendScript` - (Default: false) Append livereload `<script>`
+- `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.
 
 ## Why?

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
   return [
     '// webpack-livereload-plugin',
     '(function() {',
+    '  if (typeof window === "undefined") { return };',
     '  var id = "webpack-livereload-plugin-script";',
     '  if (document.getElementById(id)) { return; }',
     '  var el = document.createElement("script");',


### PR DESCRIPTION
When using ExtractTextPlugin, code in the module gets evaluated, and `document` is undefined in node, so I've added a check for it. Also tweaked the README to match the actual option property. Thanks for creating this plugin, btw. Very useful and something I've been meaning to build myself.