### PR TITLE
Replace tiny-lr with mini-lr for npm v3 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /* jshint node:true */
-var tinylr = require('tiny-lr');
+var minilr = require('mini-lr');
 var servers = {};
 
 function LiveReloadPlugin(options) {
@@ -20,7 +20,7 @@ LiveReloadPlugin.prototype.start = function start(watching, cb) {
     cb();
   }
   else {
-    this.server = servers[port] = tinylr(this.options);
+    this.server = servers[port] = minilr(this.options);
     this.server.errorListener = function serverError(err) {
       console.error('Live Reload disabled: ' + err.message);
       if (err.code !== 'EADDRINUSE') {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/statianzo/webpack-livereload-plugin#readme",
   "dependencies": {
-    "tiny-lr": "^0.1.6"
+    "mini-lr": "^0.1.8"
   }
 }


### PR DESCRIPTION
Tiny-lr has an issue with npm v3's flat module directory, reference [here](https://github.com/mklabs/tiny-lr/issues/91).

However, the project hasn't been updated in quite some time, and the maintainers have a history of abandoning it.  In order to unblock npm v3 users, I've forked the project and released it under the name `mini-lr`. You can find the new repository [here](http://jhawk.co/mini-lr). I recommend updating your project to use the latest release in order to enable npm v3 usage. Thanks!