### PR TITLE
Example of reload notification occurring before bundle is valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,11 @@ LiveReloadPlugin.prototype.done = function done(stats) {
 
   if (this.isRunning && hash !== this.lastHash && include.length > 0) {
     this.lastHash = hash;
-    this.server.notifyClients(include);
+    console.log('>>> Previous notifyClients');
+    setTimeout(function () {
+      this.server.notifyClients(include);
+      console.log('>>> notifyClients');
+    }.bind(this));
   }
 };
 


### PR DESCRIPTION
After updating a number of dev dependencies, I am no longer receiving reload notification at the proper time.  After a rebundle or two, my browser is reloading _just_ before the new bundle is ready.  I can't say what is leading to this as I haven't yet debugged, but this example code solves the issue reliably.  I am running webpack `1.12.13` and webpack-livereload-plugin `0.5.3`.

If you find this a reasonable workaround and want to merge I can remove the console logging, otherwise please feel free to disregard this PR and make a quick update yourself.  For now, I am going with a patched version this project kept locally unless/until I have time to debug for a more correct solution.

Sample output after the fix.  Notice that the previous call location of `notifyClients()` happens before Webpack shows a successful bundle, and the new, debounced location of `notifyClients()` happens immediately after `bundle is now VALID` (as expected).

```
 [1795] ./src/views/user-settings/reducer/user-settings-form-reducer.spec.js 2.16 kB {1} [optional]
 [1796] ./src/views/verify-security-questions/reducer/verify-security-questions-reducer.spec.js 3.98 kB {1} [optional]
 [1797] ./src/views/workspace/reducer/workspace-reducer.spec.js 1.13 kB {1} [optional]
webpack: bundle is now VALID.
>>> notifyClients
Chrome 48.0.2564 (Mac OS X 10.11.3): Executed 40 of 302 (skipped 3) SUCCESS (0 secs / 2.024 secs)
webpack: bundle is now INVALID.
>>> Previous notifyClients
Hash: a22e168b6ce46ab6f2fa
Version: webpack 1.12.13
Time: 1912ms
                                     Asset       Size  Chunks             Chunk Names
 fonts/HelveticaNeueeTextPro-BoldItali.otf    58.3 kB
                     images/x_btn_dark.png     1.7 kB
                      images/edit-icon.png  358 bytes
                   images/project-icon.png    6.12 kB
```