### PR TITLE
Adding "host" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a script tag to your page pointed at the livereload server
 
 
 ## Options
-
+- `host` - Override the host name
 - `port` - (Default: 35729) The desired port for the livereload server
 - `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a script tag to your page pointed at the livereload server
 
 
 ## Options
-- `host` - Override the host name
+
 - `port` - (Default: 35729) The desired port for the livereload server
 - `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.

--- a/index.js
+++ b/index.js
@@ -65,10 +65,9 @@ LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
     '  var id = "webpack-livereload-plugin-script";',
     '  if (document.getElementById(id)) { return; }',
     '  var el = document.createElement("script");',
-    '  var host = "' + this.options.host + '" || window.location.hostname',
     '  el.id = id;',
     '  el.async = true;',
-    '  el.src = "http://" + host + ":' + this.port + '/livereload.js";',
+    '  el.src = "http://localhost:' + this.port + '/livereload.js";',
     '  document.head.appendChild(el);',
     '}());',
     ''

--- a/index.js
+++ b/index.js
@@ -65,9 +65,10 @@ LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
     '  var id = "webpack-livereload-plugin-script";',
     '  if (document.getElementById(id)) { return; }',
     '  var el = document.createElement("script");',
+    '  var host = "' + this.options.host + '" || window.location.hostname',
     '  el.id = id;',
     '  el.async = true;',
-    '  el.src = "http://" + window.location.hostname + ":' + this.port + '/livereload.js";',
+    '  el.src = "http://" + host + ":' + this.port + '/livereload.js";',
     '  document.head.appendChild(el);',
     '}());',
     ''


### PR DESCRIPTION
When using in a different domain it is necessary to change the host name.
In my case I'm working from a local domain `example.dev` and need to load the script from `http://localhost:35729/livereload.js`

Usage:
```js
        new LiveReloadPlugin({
            appendScriptTag: true,
            host: 'localhost'
        })
```