### PR TITLE
Add documentation for `hostname` option in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Add a script tag to your page pointed at the livereload server
 ## Options
 
 - `port` - (Default: 35729) The desired port for the livereload server
+- `hostname` - (Default: `localhost`) The desired hostname for the appended
+               `<script>` (if present) to point to
 - `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.
 - `ignore` - (Default: `null`) RegExp of files to ignore. Null value means


### PR DESCRIPTION
I wasn't aware of this feature until I looked in the source, and thought it deserved mention in the README!