### PR TITLE
Added quiet mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ function LiveReloadPlugin(options) {
   this.options = options || {};
   this.port = this.options.port || 35729;
   this.ignore = this.options.ignore || null;
+  this.quiet = this.options.quiet || false;
+
   this.lastHash = null;
   this.lastChildHashes = [];
   this.hostname = this.options.hostname || 'localhost';
@@ -22,6 +24,7 @@ Object.defineProperty(LiveReloadPlugin.prototype, 'isRunning', {
 
 LiveReloadPlugin.prototype.start = function start(watching, cb) {
   var port = this.port;
+  var quiet = this.quiet;
   if (servers[port]) {
     this.server = servers[port];
     cb();
@@ -36,7 +39,7 @@ LiveReloadPlugin.prototype.start = function start(watching, cb) {
       cb();
     };
     this.server.listen(this.port, function serverStarted(err) {
-      if (!err) {
+      if (!err && !quiet) {
         console.log('Live Reload listening on port ' + port + '\n');
       }
       cb();

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ test('default options', function(t) {
   t.equal(plugin.port, 35729);
   t.equal(plugin.ignore, null);
   t.equal(plugin.isRunning, false);
+  t.equal(plugin.quiet, false);
   t.end();
 });
 


### PR DESCRIPTION
The quiet mode allows users to prevent the `Live Reload listening on port 35729` from appearing in the console.

I hope the PR is alright :-)