### PR TITLE
Add clientPort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Add a script tag to your page pointed at the livereload server
 
 - `protocol` - (Default: protocol of the page, either `http` or `https`) Protocol for livereload `<script>` src attribute value
 - `port` - (Default: 35729) The desired port for the livereload server
+- `clientPort` (defualt: same as `port` option) The port to use in the `<script>` tag (if present).
 - `hostname` - (Default: hostname of the page, like `localhost` or `10.0.2.2`) The desired hostname for the appended
                `<script>` (if present) to point to
 - `appendScriptTag` - (Default: false) Append livereload `<script>`

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var servers = {};
 function LiveReloadPlugin(options) {
   this.options = options || {};
   this.port = this.options.port || 35729;
+  this.clientPort = this.options.clientPort || this.port;
   this.ignore = this.options.ignore || null;
   this.quiet = this.options.quiet || false;
 
@@ -80,7 +81,7 @@ LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
     '  var el = document.createElement("script");',
     '  el.id = id;',
     '  el.async = true;',
-    '  el.src = "' + this.protocol + '//' + this.hostname + ':' + this.port + '/livereload.js";',
+    '  el.src = "' + this.protocol + '//' + this.hostname + ':' + this.clientPort + '/livereload.js";',
     '  document.getElementsByTagName("head")[0].appendChild(el);',
     '}());',
     ''

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var LiveReloadPlugin = require('./index');
 test('default options', function(t) {
   var plugin = new LiveReloadPlugin();
   t.equal(plugin.port, 35729);
+  t.equal(plugin.clientPort, 35729);
   t.equal(plugin.ignore, null);
   t.equal(plugin.isRunning, false);
   t.equal(plugin.quiet, false);
@@ -97,3 +98,22 @@ test('autoloadJs contains hostname option', function(t) {
   t.assert(plugin.autoloadJs().match(/example.com/));
   t.end();
 });
+
+test('autoloadJs port option', function(t) {
+  var plugin = new LiveReloadPlugin({port: 3000});
+  t.equal(plugin.port, 3000);
+  t.equal(plugin.clientPort, 3000);
+  t.assert(plugin.autoloadJs().match(/\":3000\/livereload\.js/));
+  t.assert(!plugin.autoloadJs().match(/\":35729\/livereload\.js/));
+  t.end();
+});
+
+test('autoloadJs clientPort option', function(t) {
+  var plugin = new LiveReloadPlugin({port: 3000, clientPort: 5000});
+  t.equal(plugin.port, 3000);
+  t.equal(plugin.clientPort, 5000);
+  t.assert(plugin.autoloadJs().match(/\":5000\/livereload\.js/));
+  t.assert(!plugin.autoloadJs().match(/\":3000\/livereload\.js/));
+  t.end();
+});
+


### PR DESCRIPTION
I've got a project where our development environments are required to be run on a remote server where I can only access port 80 of the server due to firewalls, so I wanted to setup nginx in that project as a reverse proxy for live reload requests via port 80 - which means I need to configure the client port in the script tag separately to the server port option.

This PR adds a separate `clientPort` option which defaults to the current value of `port` if not provided.