### PR TITLE
add delay option in case of longer builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Add a script tag to your page pointed at the livereload server
                    automatically to `<head>`.
 - `ignore` - (Default: `null`) RegExp of files to ignore. Null value means
   ignore nothing.
+- `delay` - (Default: `0`) amount of milliseconds by which to delay the live reload (in case build takes longer)
 
 ## Why?
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function LiveReloadPlugin(options) {
   this.ignore = this.options.ignore || null;
   this.quiet = this.options.quiet || false;
 
+  // add delay, but remove it from options, so it doesn't get passed to tinylr
+  this.delay = this.options.delay || 0;
+  delete this.options.delay;
+
   this.lastHash = null;
   this.lastChildHashes = [];
   this.protocol = this.options.protocol ? this.options.protocol + ':' : '';
@@ -61,7 +65,7 @@ LiveReloadPlugin.prototype.done = function done(stats) {
     this.lastChildHashes = childHashes;
     setTimeout(function onTimeout() {
       this.server.notifyClients(include);
-    }.bind(this));
+    }.bind(this), this.delay);
   }
 };
 


### PR DESCRIPTION
Ran into the same issue as #25 where the reload had to be delayed due to longer build times.

Unfortunately, this option won't get included in tiny-lr (see https://github.com/mklabs/tiny-lr/issues/110) so I decided to add it here instead.