### PR TITLE
add scriptPort config option for Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Add a script tag to your page pointed at the livereload server
                `<script>` (if present) to point to
 - `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.
+- `scriptPort` - (Default: `null`) Use a different port for the `appendScriptTag` (useful when server runs in a Docker container)
 - `ignore` - (Default: `null`) RegExp of files to ignore. Null value means
   ignore nothing.
 - `delay` - (Default: `0`) amount of milliseconds by which to delay the live reload (in case build takes longer)

--- a/index.js
+++ b/index.js
@@ -75,6 +75,8 @@ LiveReloadPlugin.prototype.failed = function failed() {
 };
 
 LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
+  var port = this.options.scriptPort || this.port;
+  var src = this.protocol + '//' + this.hostname + ':' + port + '/livereload.js';
   return [
     '// webpack-livereload-plugin',
     '(function() {',
@@ -84,7 +86,7 @@ LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
     '  var el = document.createElement("script");',
     '  el.id = id;',
     '  el.async = true;',
-    '  el.src = "' + this.protocol + '//' + this.hostname + ':' + this.port + '/livereload.js";',
+    '  el.src = "' + src + '";',
     '  document.getElementsByTagName("head")[0].appendChild(el);',
     '}());',
     ''

--- a/test.js
+++ b/test.js
@@ -97,3 +97,15 @@ test('autoloadJs contains hostname option', function(t) {
   t.assert(plugin.autoloadJs().match(/example.com/));
   t.end();
 });
+
+test('autoloadJs port is same as default', function(t) {
+  var plugin = new LiveReloadPlugin({hostname: 'example.com'});
+  t.assert(plugin.autoloadJs().match(/example.com:35729/));
+  t.end();
+});
+
+test('autoloadJs port is replaced with scriptPort', function(t) {
+  var plugin = new LiveReloadPlugin({scriptPort: 1337, hostname: 'example.com'});
+  t.assert(plugin.autoloadJs().match(/example.com:1337/));
+  t.end();
+});


### PR DESCRIPTION
@statianzo please take a look to see if this is ok with you and let me know.

Basically the issue is that when running a livereload server within a Docker container the host port differs from the container port (e.g. `61028:35729`). Adding this config allows for dynamically setting the script port so that the host machine can access the livereload server.