### PR TITLE
Upgraded tiny-lr to v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "tape": "^4.4.0"
   },
   "dependencies": {
-    "tiny-lr": "^0.2.0"
+    "tiny-lr": "^1.1.1"
   }
 }


### PR DESCRIPTION
The currently used version, ^0.2.0, has a bug we're running into.

tiny-lr/lib/server.js causes a `next is not a function` error when handling errors.

I can't tell from tiny-lr's repo whether there were any breaking changes between 0.2.0 and 1.1.1, but it doesn't look like it.

It would be nice to get this merged into the v1 branch, too, so it can be used with webpack3 as well. And then release v1.0.1.

Thanks!