### PR TITLE
Random instanceId for each plugin. Fixes #48

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /* jshint node:true */
+const crypto = require('crypto');
 var lr = require('tiny-lr');
 var servers = {};
 
@@ -7,6 +8,8 @@ function LiveReloadPlugin(options) {
   this.port = this.options.port || 35729;
   this.ignore = this.options.ignore || null;
   this.quiet = this.options.quiet || false;
+  // Random alphanumeric string appended to id to allow multiple instances of live reload
+  this.instanceId = crypto.randomBytes(8).toString('hex');
 
   // add delay, but remove it from options, so it doesn't get passed to tinylr
   this.delay = this.options.delay || 0;
@@ -79,7 +82,7 @@ LiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
     '// webpack-livereload-plugin',
     '(function() {',
     '  if (typeof window === "undefined") { return };',
-    '  var id = "webpack-livereload-plugin-script";',
+    '  var id = "webpack-livereload-plugin-script-' + this.instanceId + '";',
     '  if (document.getElementById(id)) { return; }',
     '  var el = document.createElement("script");',
     '  el.id = id;',

--- a/test.js
+++ b/test.js
@@ -97,3 +97,16 @@ test('autoloadJs contains hostname option', function(t) {
   t.assert(plugin.autoloadJs().match(/example.com/));
   t.end();
 });
+
+test('every instance has random id', function(t) {
+  var plugin = new LiveReloadPlugin();
+  var plugin2 = new LiveReloadPlugin();
+  t.notEqual(plugin.instanceId, plugin2.instanceId);
+  t.end();
+});
+
+test('autoloadJs contains instanceId', function(t) {
+  var plugin = new LiveReloadPlugin();
+  t.assert(plugin.autoloadJs().match(plugin.instanceId));
+  t.end();
+});


### PR DESCRIPTION
Add random alphanumeric string to injected live reload id to allow
multiple instances on one page

This is an updated version of #49.

Also, bumps the travis-ci node version to a recent version of node