### PR TITLE
Feature: port 0 will search for a free port, like webpack-dev-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add a script tag to your page pointed at the livereload server
 ## Options
 
 - `protocol` - (Default: protocol of the page, either `http` or `https`) Protocol for livereload `<script>` src attribute value
-- `port` - (Default: 35729) The desired port for the livereload server
+- `port` - (Default: 35729) The desired port for the livereload server. If you define port 0, an available port will be searched for, starting from 35729.
 - `hostname` - (Default: hostname of the page, like `localhost` or `10.0.2.2`) The desired hostname for the appended
                `<script>` (if present) to point to
 - `appendScriptTag` - (Default: false) Append livereload `<script>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -15,10 +20,10 @@
       "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "requires": {
-        "continuable-cache": "^0.3.1",
-        "error": "^7.0.0",
-        "raw-body": "~1.1.0",
-        "safe-json-parse": "~1.0.1"
+        "continuable-cache": "0.3.1",
+        "error": "7.0.2",
+        "raw-body": "1.1.7",
+        "safe-json-parse": "1.0.1"
       }
     },
     "brace-expansion": {
@@ -27,7 +32,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -73,8 +78,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
       },
       "dependencies": {
         "object-keys": {
@@ -102,8 +107,8 @@
       "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "0.2.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "xtend": {
@@ -119,11 +124,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -132,9 +137,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "faucet": {
@@ -144,12 +149,12 @@
       "dev": true,
       "requires": {
         "defined": "0.0.0",
-        "duplexer": "~0.1.1",
+        "duplexer": "0.1.1",
         "minimist": "0.0.5",
-        "sprintf": "~0.1.3",
-        "tap-parser": "~0.4.0",
-        "tape": "~2.3.2",
-        "through2": "~0.2.3"
+        "sprintf": "0.1.5",
+        "tap-parser": "0.4.3",
+        "tape": "2.3.3",
+        "through2": "0.2.3"
       },
       "dependencies": {
         "tape": {
@@ -158,12 +163,12 @@
           "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
           "dev": true,
           "requires": {
-            "deep-equal": "~0.1.0",
-            "defined": "~0.0.0",
-            "inherits": "~2.0.1",
-            "jsonify": "~0.0.0",
-            "resumer": "~0.0.0",
-            "through": "~2.3.4"
+            "deep-equal": "0.1.2",
+            "defined": "0.0.0",
+            "inherits": "2.0.3",
+            "jsonify": "0.0.0",
+            "resumer": "0.0.0",
+            "through": "2.3.8"
           }
         }
       }
@@ -173,7 +178,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "for-each": {
@@ -182,7 +187,7 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.3"
       }
     },
     "foreach": {
@@ -209,12 +214,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "has": {
@@ -223,7 +228,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "http-parser-js": {
@@ -237,8 +242,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -265,7 +270,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-symbol": {
@@ -297,7 +302,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -305,6 +310,21 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
       "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
       "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -334,7 +354,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -349,6 +369,26 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "portfinder": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
+      "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -359,8 +399,8 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
       "requires": {
-        "bytes": "1",
-        "string_decoder": "0.10"
+        "bytes": "1.0.0",
+        "string_decoder": "0.10.31"
       }
     },
     "readable-stream": {
@@ -369,10 +409,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "resolve": {
@@ -381,7 +421,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resumer": {
@@ -390,7 +430,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "safe-json-parse": {
@@ -415,9 +455,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -431,8 +471,8 @@
       "integrity": "sha1-pOrhkMENdsehEZIf84u+TVjwnuo=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~1.1.11"
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14"
       }
     },
     "tape": {
@@ -441,19 +481,19 @@
       "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
       "dev": true,
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.3",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
-        "has": "~1.0.3",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.3",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.3",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.6.0",
+        "resolve": "1.7.1",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       },
       "dependencies": {
         "deep-equal": {
@@ -488,8 +528,8 @@
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9",
-        "xtend": "~2.1.1"
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
       }
     },
     "tiny-lr": {
@@ -497,12 +537,12 @@
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
       "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "requires": {
-        "body": "^5.1.0",
-        "debug": "^3.1.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.3.0",
-        "object-assign": "^4.1.0",
-        "qs": "^6.4.0"
+        "body": "5.1.0",
+        "debug": "3.1.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.3.0",
+        "object-assign": "4.1.1",
+        "qs": "6.5.2"
       }
     },
     "websocket-driver": {
@@ -510,8 +550,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.13",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -531,7 +571,7 @@
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dev": true,
       "requires": {
-        "object-keys": "~0.4.0"
+        "object-keys": "0.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
+    "portfinder": "^1.0.17",
     "tiny-lr": "^1.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -28,6 +28,35 @@ test('running after start', function(t) {
   });
 });
 
+test('finds available ports', function(t) {
+  var plugin1 = new LiveReloadPlugin({port: 0});
+  var plugin2 = new LiveReloadPlugin({port: 0});
+
+  var count = 0;
+  var tryEnd = function() {
+    count++;
+    if(count === 2) {
+      t.ok(plugin1.port !== plugin2.port);
+      t.end();
+    }
+  }
+
+  var startPlugin = function(p) {
+    p.start(null, function() {
+      t.notLooseEqual(p.server, null);
+      t.ok(p.server !== undefined)
+      t.ok(p.isRunning);
+      p.server.on('close', function() {
+        tryEnd();
+      });
+      p.server.close();
+    });
+  }.bind(this);
+
+  startPlugin(plugin1);
+  startPlugin(plugin2);
+});
+
 test('notifies when done', function(t) {
   var plugin = new LiveReloadPlugin();
   var stats = {


### PR DESCRIPTION
If you run multiple webpack configurations in parallel and want to have livereload available in all of them, you need to specify a unique port for each of them. If you have a general solution for deploying micro-frontends with a variable number of webpack instances, this is not ideal.

This PR mimics the webpack-dev-server behavior down to the package dependency (portfinder). code found here: https://github.com/webpack/webpack-dev-server/blob/474022476dc14756f437c1a3f7397f178135453d/bin/webpack-dev-server.js