### PR TITLE
Fix notify by all changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add a script tag to your page pointed at the livereload server
 - `appendScriptTag` - (Default: false) Append livereload `<script>`
                    automatically to `<head>`.
 - `ignore` - (Default: `null`) RegExp of files to ignore. Null value means
-  ignore nothing.
+  ignore nothing. It is also possible to define an array and use multiple [anymatch](https://github.com/micromatch/anymatch) patterns.
 - `delay` - (Default: `0`) amount of milliseconds by which to delay the live reload (in case build takes longer)
 
 ## Why?
@@ -61,3 +61,11 @@ triggered from webpack's build pipeline.
 If you set `key`, `cert`, or `pfx` options, they'll get passed through to
 [tiny-lr as options](https://github.com/mklabs/tiny-lr#options) and it will
 serve over HTTPS. You'll also also set `protocol` to `https`.
+
+## FAQ
+
+##### Webpack always generates js and css together
+
+If your webpack is always generating js and css files it will trigger 
+multiple reloads. You could set `liveCSS` and `liveImg` to `false` 
+to prevent multiple reloads.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Add a script tag to your page pointed at the livereload server
 - `ignore` - (Default: `null`) RegExp of files to ignore. Null value means
   ignore nothing. It is also possible to define an array and use multiple [anymatch](https://github.com/micromatch/anymatch) patterns.
 - `delay` - (Default: `0`) amount of milliseconds by which to delay the live reload (in case build takes longer)
+- `useSourceHash` - (Default: `false`) create hash for each file source and only notify livereload if hash has changed
 
 ## Why?
 
@@ -66,6 +67,9 @@ serve over HTTPS. You'll also also set `protocol` to `https`.
 
 ##### Webpack always generates js and css together
 
-If your webpack is always generating js and css files it will trigger 
-multiple reloads. You could set `liveCSS` and `liveImg` to `false` 
-to prevent multiple reloads.
+If your webpack is always generating js and css files together you could set 
+`useSourceHash` to `true` to generate a hash for each changed asset and it 
+should prevent multiple reloads. 
+
+Alternatively if this slows your build process you could set `liveCSS` 
+and `liveImg` to `false` to prevent multiple reloads.

--- a/index.js
+++ b/index.js
@@ -35,16 +35,11 @@ Object.defineProperty(LiveReloadPlugin.prototype, 'isRunning', {
   get: function() { return !!this.server; }
 });
 
-String.prototype.hashCode = function() {
-  var hash = 0, i, chr;
-  if (this.length === 0) return hash;
-  for (i = 0; i < this.length; i++) {
-    chr   = this.charCodeAt(i);
-    hash  = ((hash << 5) - hash) + chr;
-    hash |= 0; // Convert to 32bit integer
-  }
-  return hash;
-};
+function generateHashCode(str) {
+  const hash = crypto.createHash('sha256');
+  hash.update(str);
+  return hash.digest('hex');
+}
 
 function fileIgnoredOrNotEmitted(data) {
   if (Array.isArray(this.ignore)) {
@@ -57,7 +52,7 @@ function fileHashDoesntMatches(data) {
   if (!this.useSourceHash)
     return true;
 
-  const sourceHash = data[1].source().hashCode();
+  const sourceHash = generateHashCode(data[1].source());
   if (
       this.sourceHashs.hasOwnProperty(data[0])
       && this.sourceHashs[data[0]] === sourceHash

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -331,6 +340,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -368,6 +382,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "portfinder": {
       "version": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "portfinder": "^1.0.17",
-    "tiny-lr": "^1.1.1"
+    "tiny-lr": "^1.1.1",
+    "anymatch": "^3.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var test = require('tape');
+const crypto = require('crypto');
 var LiveReloadPlugin = require('./index');
 
 test('default options', function(t) {
@@ -117,8 +118,13 @@ test('filters out ignored files as array', function(t) {
 });
 
 test('filters out hashed files', function(t) {
+  function hashCode(str) {
+    const hash = crypto.createHash('sha256');
+    hash.update(str);
+    return hash.digest('hex');
+  }
+
   var plugin = new LiveReloadPlugin({
-    ignore: [/.map/, /.json/],
     useSourceHash: true,
   });
   var stats = {
@@ -141,8 +147,8 @@ test('filters out hashed files', function(t) {
     }
   };
   plugin.sourceHashs = {
-    'b.js': 9999999,
-    'a.js': 3003444,
+    'b.js': 'Wrong hash',
+    'a.js': hashCode('asdf'),
   };
   plugin.server = {
     notifyClients: function(files) {

--- a/test.js
+++ b/test.js
@@ -39,7 +39,7 @@ test('finds available ports', function(t) {
       t.notEqual(plugin1.port, plugin2.port);
       t.end();
     }
-  }
+  };
 
   var startPlugin = function(p) {
     p.start(null, function() {
@@ -53,7 +53,7 @@ test('finds available ports', function(t) {
         p.server.close();
       });
     });
-  }
+  };
 
   startPlugin(plugin1);
   startPlugin(plugin2);
@@ -110,6 +110,43 @@ test('filters out ignored files as array', function(t) {
   plugin.server = {
     notifyClients: function(files) {
       t.deepEqual(files.sort(), ['a.js', 'b.js']);
+      t.end();
+    }
+  };
+  plugin.done(stats);
+});
+
+test('filters out hashed files', function(t) {
+  var plugin = new LiveReloadPlugin({
+    ignore: [/.map/, /.json/],
+    useSourceHash: true,
+  });
+  var stats = {
+    compilation: {
+      assets: {
+        'b.js': {
+          emitted: true,
+          source: function() {
+            return "asdf";
+          },
+        },
+        'a.js': {
+          emitted: true,
+          source: function() {
+            return "asdf";
+          },
+        },
+      },
+      children: []
+    }
+  };
+  plugin.sourceHashs = {
+    'b.js': 9999999,
+    'a.js': 3003444,
+  };
+  plugin.server = {
+    notifyClients: function(files) {
+      t.deepEqual(files.sort(), ['b.js']);
       t.end();
     }
   };

--- a/test.js
+++ b/test.js
@@ -63,7 +63,7 @@ test('notifies when done', function(t) {
   var plugin = new LiveReloadPlugin();
   var stats = {
     compilation: {
-      assets: {'b.js': '123', 'a.js': '456', 'c.css': '789'},
+      assets: {'b.js': {emitted: true}, 'a.js': {emitted: true}, 'c.css': {emitted: true}, 'd.css': {emitted: false}},
       hash: 'hash',
       children: []
     }
@@ -84,7 +84,26 @@ test('filters out ignored files', function(t) {
   });
   var stats = {
     compilation: {
-      assets: {'b.js': '123', 'a.js': '456', 'c.css': '789'},
+      assets: {'b.js': {emitted: true}, 'a.js': {emitted: true}, 'c.css': {emitted: true}, 'd.css': {emitted: false}},
+      children: []
+    }
+  };
+  plugin.server = {
+    notifyClients: function(files) {
+      t.deepEqual(files.sort(), ['a.js', 'b.js']);
+      t.end();
+    }
+  };
+  plugin.done(stats);
+});
+
+test('filters out ignored files as array', function(t) {
+  var plugin = new LiveReloadPlugin({
+    ignore: [/.map/, /.json/]
+  });
+  var stats = {
+    compilation: {
+      assets: {'b.js': {emitted: true}, 'a.js': {emitted: true}, 'c.map': {emitted: true}, 'd.json': {emitted: true}},
       children: []
     }
   };
@@ -101,7 +120,7 @@ test('children trigger notification', function(t) {
   var plugin = new LiveReloadPlugin();
   var stats = {
     compilation: {
-      assets: {'b.js': '123', 'a.js': '456', 'c.css': '789'},
+      assets: {'b.js': {emitted: true}, 'a.js': {emitted: true}, 'c.css': {emitted: false}},
       hash: null,
       children: [{hash:'hash'}]
     }


### PR DESCRIPTION
I changed the logic of file changes detection to check for emitted. Now only the newly written files will be notified.
For ignore i added the anymatch because its easier to use when ignoring different files.
Added extra logic for array to have backwards compatibility.

The last problem which i can't resolve is that webpack will always generate multiple assets when you have enabled MiniCssExtractPlugin for example.
There is no hash for assets. Only for the whole chunk. So this can't be solved currently.